### PR TITLE
Cambiare Correct exchange rates

### DIFF
--- a/cambiare_gtq/api_cambiare.py
+++ b/cambiare_gtq/api_cambiare.py
@@ -92,31 +92,53 @@ def crear_cambio_moneda(cambio, fecha, factor_1usd_xgtq, moneda_cod_letras='USD'
     '''
 
     try:
-        usd_to_gtq = frappe.new_doc("Currency Exchange")
-        usd_to_gtq.date = datetime.datetime.strptime(fecha, '%d/%m/%Y').date()  # frappe.utils.nowdate()
-        usd_to_gtq.from_currency = moneda_cod_letras
-        usd_to_gtq.to_currency = 'GTQ'
-        usd_to_gtq.exchange_rate = float(cambio)
-        usd_to_gtq.for_buying = True
-        usd_to_gtq.for_selling = True
-        usd_to_gtq.save()
+        if moneda_cod_letras != 'USD':
+            result = float(factor_1usd_xgtq) / float(cambio)
+            any_to_gtq = frappe.new_doc("Currency Exchange")  # Crea un nuevo registro para el doctype
+            any_to_gtq.date = datetime.datetime.strptime(fecha, '%d/%m/%Y').date()  # frappe.utils.nowdate()
+            any_to_gtq.from_currency = moneda_cod_letras
+            any_to_gtq.to_currency = 'GTQ'
+            any_to_gtq.exchange_rate = float(result)
+            any_to_gtq.for_buying = True
+            any_to_gtq.for_selling = True
+            any_to_gtq.save()
+
+        else:
+            usd_to_gtq = frappe.new_doc("Currency Exchange")
+            usd_to_gtq.date = datetime.datetime.strptime(fecha, '%d/%m/%Y').date()  # frappe.utils.nowdate()
+            usd_to_gtq.from_currency = moneda_cod_letras
+            usd_to_gtq.to_currency = 'GTQ'
+            usd_to_gtq.exchange_rate = float(cambio)
+            usd_to_gtq.for_buying = True
+            usd_to_gtq.for_selling = True
+            usd_to_gtq.save()
     except:
         return 'No se pudo crear tipo cambio USD to GTQ, intentar manualmente'
     else:
         try:
-            gtq_to_usd = frappe.new_doc("Currency Exchange")
-            gtq_to_usd.date = datetime.datetime.strptime(fecha, '%d/%m/%Y').date()   # frappe.utils.nowdate()
-            gtq_to_usd.from_currency = 'GTQ'
-            gtq_to_usd.to_currency = moneda_cod_letras
-            gtq_to_usd.exchange_rate = 1/float(cambio)
-            gtq_to_usd.for_buying = True
-            gtq_to_usd.for_selling = True
-            gtq_to_usd.save()
+            if moneda_cod_letras != 'USD':
+                result = float(factor_1usd_xgtq) / float(cambio)
+                any_to_usd = frappe.new_doc("Currency Exchange")
+                any_to_usd.date = datetime.datetime.strptime(fecha, '%d/%m/%Y').date()   # frappe.utils.nowdate()
+                any_to_usd.from_currency = 'GTQ'
+                any_to_usd.to_currency = moneda_cod_letras
+                any_to_usd.exchange_rate = 1/float(result)
+                any_to_usd.for_buying = True
+                any_to_usd.for_selling = True
+                any_to_usd.save()
+            else:
+                gtq_to_usd = frappe.new_doc("Currency Exchange")
+                gtq_to_usd.date = datetime.datetime.strptime(fecha, '%d/%m/%Y').date()   # frappe.utils.nowdate()
+                gtq_to_usd.from_currency = 'GTQ'
+                gtq_to_usd.to_currency = moneda_cod_letras
+                gtq_to_usd.exchange_rate = 1/float(cambio)
+                gtq_to_usd.for_buying = True
+                gtq_to_usd.for_selling = True
+                gtq_to_usd.save()
         except:
             return 'No se pudo crear tipo cambio GTQ to USD, intentar manualmente'
         else:
             return 'Currency Exchange OK'
-
 
 @frappe.whitelist()
 def preparar_peticion_banguat(opt, fecha_ini=0, fecha_fin=0, moneda=2):

--- a/cambiare_gtq/cambiare_gtq/doctype/configuration_cambiare/configuration_cambiare.js
+++ b/cambiare_gtq/cambiare_gtq/doctype/configuration_cambiare/configuration_cambiare.js
@@ -2,68 +2,65 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Configuration Cambiare', {
-	refresh: function (frm) {
-		// console.log('Se refreso form');
-		consulta_tipo_cambio_dia(frm)
-
-		// Obtiene las monedas disponibles de la API banguat
-		// frappe.call({
-		// 	method: "cambiare_gtq.api_cambiare.preparar_peticion_banguat",
-		// 	args: {
-		// 		opt: '6'
-		// 	},
-		// 	freeze: true,
-		// 	freeze_message: __("Obteniendo y guardando monedas disponibles del Banco de Guatemala..."),
-		// 	callback: function (r) {
-		// 		if (!r.exc) {
-		// 			clearInterval(frm.page["interval"]);
-		// 			// console.log(r.message)
-
-		// 			frappe.meta.get_docfield('Available Currencies', 'moneda', cur_frm.doc.name).options = r.message
-		// 			cur_frm.refresh_field('moneda');
-		// 		}
-		// 	}
-		// });
-
-	}
+    refresh: function (frm) {
+        // console.log('Se refresco form');
+        consulta_tipo_cambio_dia(frm)
+        // Obtiene las monedas disponibles de la API banguat
+        // frappe.call({
+        // 	method: "cambiare_gtq.api_cambiare.preparar_peticion_banguat",
+        // 	args: {
+        // 		opt: '6'
+        // 	},
+        // 	freeze: true,
+        // 	freeze_message: __("Obteniendo y guardando monedas disponibles del Banco de Guatemala..."),
+        // 	callback: function (r) {
+        // 		if (!r.exc) {
+        // 			clearInterval(frm.page["interval"]);
+        // 			// console.log(r.message)
+        // 			frappe.meta.get_docfield('Available Currencies', 'moneda', cur_frm.doc.name).options = r.message
+        // 			cur_frm.refresh_field('moneda');
+        // 		}
+        // 	}
+        // });
+    }
 });
 
 let consulta_tipo_cambio_dia = function (frm) {
-	// Agrega un boton para consumir el webservice manualmente
-	frm.page.set_secondary_action(__("Tipo Cambio Manual"), function () {
-		frappe.call({
-			method: "cambiare_gtq.api_cambiare.preparar_peticion_banguat",
-			args: {
-				opt: '6'
-			},
-			freeze: true,
-			freeze_message: __("Consultado tipo cambio del dia de las monedas seleccionadas..."),
-			callback: function (r) {
-				if (!r.exc) {
-					clearInterval(frm.page["interval"]);
-					// frm.page.set_indicator(__('Importacion Exitosa!!'), 'blue');
-					// create_reset_button(frm);
-					console.log(r.message)
-				}
-			}
-		});
-		frappe.call({
-			method: "cambiare_gtq.api_cambiare.preparar_peticion_banguat",
-			args: {
-				opt: '1'
-			},
-			freeze: true,
-			freeze_message: __("Consultado tipo cambio del dia Dolares..."),
-			callback: function (r) {
-				if (!r.exc) {
-					clearInterval(frm.page["interval"]);
-					// frm.page.set_indicator(__('Importacion Exitosa!!'), 'blue');
-					// create_reset_button(frm);
-					console.log(r.message)
-				}
-			}
-		});
-	}).addClass('btn btn-primary');
+    // Agrega un boton para consumir el webservice manualmente
+    frm.page.set_secondary_action(__("Tipo Cambio Manual"), function () {
+        frappe.call({
+            method: "cambiare_gtq.api_cambiare.preparar_peticion_banguat",
+            args: {
+                opt: '6'
+            },
+            freeze: true,
+            freeze_message: __("Consultado tipo cambio del dia de las monedas seleccionadas..."),
+            callback: function (r) {
+                if (!r.exc) {
+                    clearInterval(frm.page["interval"]);
+                    // frm.page.set_indicator(__('Importacion Exitosa!!'), 'blue');
+                    // create_reset_button(frm);
+                    console.log(r.message)
+                }
+            }
+        });
+        frappe.call({
+            method: "cambiare_gtq.api_cambiare.preparar_peticion_banguat",
+            args: {
+                opt: '1'
+            },
+            freeze: true,
+            freeze_message: __("Consultado tipo cambio del dia Dolares..."),
+            callback: function (r) {
+                if (!r.exc) {
+                    clearInterval(frm.page["interval"]);
+                    // frm.page.set_indicator(__('Importacion Exitosa!!'), 'blue');
+                    // create_reset_button(frm);
+                    console.log(r.message)
+                }
+            }
+        });
+    }).addClass('btn btn-primary');
 }
 
 

--- a/cambiare_gtq/fixtures/translation.json
+++ b/cambiare_gtq/fixtures/translation.json
@@ -1,0 +1,16 @@
+[
+ {
+  "contributed_translation_doctype_name": null,
+  "docstatus": 0,
+  "doctype": "Translation",
+  "language": "es",
+  "modified": "2020-07-09 18:51:01.197621",
+  "name": "f6e51ae49e",
+  "parent": null,
+  "parentfield": null,
+  "parenttype": null,
+  "source_name": "Could not create USD to GTQ exchange rate, please try generating GTQ manually",
+  "status": "Saved",
+  "target_name": "No se pudo crear tipo cambio USD to GTQ, intentar manualmente GTQ"
+ }
+]

--- a/cambiare_gtq/hooks.py
+++ b/cambiare_gtq/hooks.py
@@ -5,27 +5,36 @@ from . import __version__ as app_version
 app_name = "cambiare_gtq"
 app_title = "Cambiare GTQ"
 app_publisher = "Si Hay Sistema"
-app_description = "Cambio de moneda"
+app_description = "Currency exchange API sourcing data from Guatemala's Central Bank webservice"
 app_icon = "octicon octicon-graph"
 app_color = "#27AE60"
 app_email = "m.monroyc22@gmail.com"
 app_license = "GNU General Public License v3.0"
 
-'''
-# This needs to be enabled and bench restarted before running bench export-fixtures
-such that the Custom Fields listed below can be exported.
+# This needs to be enabled and bench restarted before running bench export-fixtures such that the Custom Fields listed below can be exported.
 fixtures = [
-	{"dt": "Custom Field", "filters": [
+    {"dt": "Translation", "filters": [
         [
-            "name", "in", [
-                "Currency Exchange-validity_date_ranges",
-				"Currency Exchange-valid_to",
-				"Currency Exchange-col_break",
-				"Currency Exchange-valid_from"
+            "source_name", "in", [
+                "Could not create USD to GTQ exchange rate, please try generating GTQ manually",
             ]
         ]
     ]
-	}
+    }
+]
+'''
+fixtures = [
+    {"dt": "Custom Field", "filters": [
+        [
+            "name", "in", [
+                "Currency Exchange-validity_date_ranges",
+                "Currency Exchange-valid_to",
+                "Currency Exchange-col_break",
+                "Currency Exchange-valid_from"
+            ]
+        ]
+    ]
+    }
 ]
 '''
 # Includes in <head>
@@ -108,33 +117,33 @@ fixtures = [
 # ---------------
 
 scheduler_events = {
-	# Se ejecuta cada 4 minuts
-	# "all": [
-	# 	"cambiare_gtq.tasks.all"
-	# ],
-	# Se ejecuta cada dia 00:00
-	"daily": [
-		"cambiare_gtq.task.daily"
-	],
-	# Se ejecuta a cada hora
-	"hourly": [
-		"cambiare_gtq.task.hourly"
-	],
-	# Cron linux especificacion freq
-	# "cron": {
-	# 	# Cada minuto
-	# 	"0/01 * * * *": [
-	# 		"cambiare_gtq.task.test"
-	# 	]
-	# },
-	# Se ejecuta acada semana
-	"weekly": [
-		"cambiare_gtq.task.weekly"
-	],
-	# # Se ejecuta cada mes
-	"monthly": [
-		"cambiare_gtq.task.monthly"
-	]
+    # Se ejecuta cada 4 minuts
+    # "all": [
+    # 	"cambiare_gtq.tasks.all"
+    # ],
+    # Se ejecuta cada dia 00:00
+    "daily": [
+        "cambiare_gtq.task.daily"
+    ],
+    # Se ejecuta a cada hora
+    "hourly": [
+        "cambiare_gtq.task.hourly"
+    ],
+    # Cron linux especificacion freq
+    # "cron": {
+    # 	# Cada minuto
+    # 	"0/01 * * * *": [
+    # 		"cambiare_gtq.task.test"
+    # 	]
+    # },
+    # Se ejecuta acada semana
+    "weekly": [
+        "cambiare_gtq.task.weekly"
+    ],
+    # # Se ejecuta cada mes
+    "monthly": [
+        "cambiare_gtq.task.monthly"
+    ]
 }
 
 # Testing


### PR DESCRIPTION
Currency exchanges USD⇌GTQ  were working properly, but currency exchanges for any of the other pairs were expressed in terms per USD.  Bank of Guatemala expresses amounts in alternative currency per 1 USD. Our app intends to create GTQ, and when creating those exchange pairs it was expressing amounts per USD  and not to GTQ as intended. This corrects it by expressing from both destination currencies expressed as 1 USD.